### PR TITLE
Updated with new method for custom URLs

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -69,6 +69,24 @@ func NewClient(authToken string) *Client {
 	return c
 }
 
+// NewClient returns a new HipChat API client. You must provide a valid
+// AuthToken retrieved from your HipChat account.
+func NewClientWithCustomUrl(apiUrl string, authToken string) *Client {
+	baseURL, err := url.Parse(apiUrl)
+	if err != nil {
+		panic(err)
+	}
+
+	c := &Client{
+		authToken: authToken,
+		baseURL:   baseURL,
+		client:    http.DefaultClient,
+	}
+	c.Room = &RoomService{client: c}
+	c.User = &UserService{client: c}
+	return c
+}
+
 // NewRequest creates an API request. This method can be used to performs
 // API request not implemented in this library. Otherwise it should not be
 // be used directly.


### PR DESCRIPTION
Need the ability to use something other than base URL for private hipchat installations