### PR TITLE
Allow passing server base url as parameter

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -53,10 +53,10 @@ type ID struct {
 	ID string `json:"id"`
 }
 
-// NewClient returns a new HipChat API client. You must provide a valid
-// AuthToken retrieved from your HipChat account.
-func NewClient(authToken string) *Client {
-	baseURL, err := url.Parse(defaultBaseURL)
+// NewClientForServer returns a new HipChat API client. You must provide a valid
+// AuthToken retrieved from your HipChat account and server base url.
+func NewClientForServer(authToken string, serverBaseUrl string) *Client {
+	baseURL, err := url.Parse(serverBaseUrl)
 	if err != nil {
 		panic(err)
 	}
@@ -70,6 +70,12 @@ func NewClient(authToken string) *Client {
 	c.User = &UserService{client: c}
 	c.Emoticon = &EmoticonService{client: c}
 	return c
+}
+
+// NewClient returns a new HipChat API client. You must provide a valid
+// AuthToken retrieved from your HipChat.
+func NewClient(authToken string) *Client {
+	return NewClientForServer(authToken, defaultBaseURL)
 }
 
 // NewRequest creates an API request. This method can be used to performs

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -36,6 +36,19 @@ func teardown() {
 	server.Close()
 }
 
+func TestNewClientForServer(t *testing.T) {
+	authToken := "AuthToken"
+	serverBaseUrl := "https://example.com/v2/"
+
+	c := NewClientForServer(authToken, serverBaseUrl)
+
+	if c.authToken != authToken {
+		t.Errorf("NewClient authToken %s, want %s", c.authToken, authToken)
+	}
+	if c.BaseURL.String() != serverBaseUrl {
+		t.Errorf("NewClient BaseURL %s, want %s", c.BaseURL.String(), serverBaseUrl)
+	}
+}
 func TestNewClient(t *testing.T) {
 	authToken := "AuthToken"
 


### PR DESCRIPTION
Some companies use standalone HipChat server(s). In this case API base url differs from `defaultBaseUrl` constant. It seems to be a good idea to allow passing base url as a parameter when creating `Client`.