### PR TITLE
Added Client.GetAccessToken to allow clients to request an access token with client credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 go:
          - 1.1
          - 1.2
+         - 1.3
+         - 1.4
          - tip
 install: go get -v ./hipchat
 script: go test -v ./hipchat

--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -1,0 +1,76 @@
+package hipchat
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ClientCredentials represents the OAuth2 client ID and secret for an integration
+type ClientCredentials struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// OAuthAccessToken represents a newly created Hipchat OAuth access token
+type OAuthAccessToken struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   uint32 `json:"expires_in"`
+	GroupID     uint32 `json:"group_id"`
+	GroupName   string `json:"group_name"`
+	Scope       string `json:"scope"`
+	TokenType   string `json:"token_type"`
+}
+
+// CreateClient creates a new client from this OAuth token
+func (t *OAuthAccessToken) CreateClient() *Client {
+	return NewClient(t.AccessToken)
+}
+
+// GetAccessToken returns back an access token for a given integration's client ID and client secret
+func (c *Client) GetAccessToken(credentials ClientCredentials, scopes []string) (*OAuthAccessToken, *http.Response, error) {
+	rel, err := url.Parse("oauth/token")
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	u := c.BaseURL.ResolveReference(rel)
+
+	params := url.Values{"grant_type": {"client_credentials"}, "scopes": {strings.Join(scopes, " ")}}
+	req, err := http.NewRequest("POST", u.String(), strings.NewReader(params.Encode()))
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.SetBasicAuth(credentials.ClientID, credentials.ClientSecret)
+	req.Header.Set("Content-type", "application/x-www-form-urlencoded")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	if resp.StatusCode != 200 {
+		content, readerr := ioutil.ReadAll(resp.Body)
+
+		if readerr != nil {
+			content = []byte("Unknown error")
+		}
+
+		return nil, resp, fmt.Errorf("Couldn't retrieve access token: %s", content)
+	}
+
+	content, err := ioutil.ReadAll(resp.Body)
+
+	var token OAuthAccessToken
+	json.Unmarshal(content, &token)
+
+	return &token, resp, nil
+}

--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -74,3 +74,35 @@ func (c *Client) GetAccessToken(credentials ClientCredentials, scopes []string) 
 
 	return &token, resp, nil
 }
+
+// Scope is a string value representing access in the Hipchat API
+type Scope string
+
+const (
+	// ScopeAdminGroup - Perform group administrative tasks
+	ScopeAdminGroup Scope = "admin_group"
+
+	// ScopeAdminRoom - Perform room administrative tasks
+	ScopeAdminRoom = "admin_room"
+
+	// ScopeImportData - Import users, rooms, and chat history. Only available for select add-ons.
+	ScopeImportData = "import_data"
+
+	// ScopeManageRooms - Create, update, and remove rooms
+	ScopeManageRooms = "manage_rooms"
+
+	// ScopeSendMessage - Send private one-on-one messages
+	ScopeSendMessage = "send_message"
+
+	// ScopeSendNotification - Send room notifications
+	ScopeSendNotification = "send_notification"
+
+	// ScopeViewGroup - View users, rooms, and other group information
+	ScopeViewGroup = "view_group"
+
+	// ScopeViewMessages - View messages from chat rooms and private chats you have access to
+	ScopeViewMessages = "view_messages"
+
+	// ScopeViewRoom - View room information and participants, but not history
+	ScopeViewRoom = "view_room"
+)

--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -30,8 +30,10 @@ func (t *OAuthAccessToken) CreateClient() *Client {
 	return NewClient(t.AccessToken)
 }
 
-// GetAccessToken returns back an access token for a given integration's client ID and client secret
-func (c *Client) GetAccessToken(credentials ClientCredentials, scopes []string) (*OAuthAccessToken, *http.Response, error) {
+// GenerateToken returns back an access token for a given integration's client ID and client secret
+//
+//  HipChat API documentation: https://www.hipchat.com/docs/apiv2/method/generate_token
+func (c *Client) GenerateToken(credentials ClientCredentials, scopes []string) (*OAuthAccessToken, *http.Response, error) {
 	rel, err := url.Parse("oauth/token")
 
 	if err != nil {
@@ -40,7 +42,8 @@ func (c *Client) GetAccessToken(credentials ClientCredentials, scopes []string) 
 
 	u := c.BaseURL.ResolveReference(rel)
 
-	params := url.Values{"grant_type": {"client_credentials"}, "scopes": {strings.Join(scopes, " ")}}
+	params := url.Values{"grant_type": {"client_credentials"},
+		"scope": {strings.Join(scopes, " ")}}
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(params.Encode()))
 
 	if err != nil {
@@ -75,12 +78,9 @@ func (c *Client) GetAccessToken(credentials ClientCredentials, scopes []string) 
 	return &token, resp, nil
 }
 
-// Scope is a string value representing access in the Hipchat API
-type Scope string
-
 const (
 	// ScopeAdminGroup - Perform group administrative tasks
-	ScopeAdminGroup Scope = "admin_group"
+	ScopeAdminGroup = "admin_group"
 
 	// ScopeAdminRoom - Perform room administrative tasks
 	ScopeAdminRoom = "admin_room"

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -57,7 +57,7 @@ func TestGetAccessToken(t *testing.T) {
 
 	credentials := ClientCredentials{ClientID: clientID, ClientSecret: clientSecret}
 
-	token, _, err := client.GetAccessToken(credentials, []string{"send_notification", "view_room"})
+	token, _, err := client.GetAccessToken(credentials, []string{ScopeSendNotification, ScopeViewRoom})
 	if err != nil {
 		t.Fatalf("Client.GetAccessToken returns an error %v", err)
 	}

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -31,8 +31,8 @@ func TestGetAccessToken(t *testing.T) {
 			t.Errorf("grant_type should be 'client_credentials'")
 		}
 
-		if r.FormValue("scopes") != "send_notification view_room" {
-			t.Errorf("scopes should be 'send_notification view_room'")
+		if r.FormValue("scope") != "send_notification view_room" {
+			t.Errorf("scope should be 'send_notification view_room'")
 		}
 
 		fmt.Fprintf(w, `
@@ -57,7 +57,7 @@ func TestGetAccessToken(t *testing.T) {
 
 	credentials := ClientCredentials{ClientID: clientID, ClientSecret: clientSecret}
 
-	token, _, err := client.GetAccessToken(credentials, []string{ScopeSendNotification, ScopeViewRoom})
+	token, _, err := client.GenerateToken(credentials, []string{ScopeSendNotification, ScopeViewRoom})
 	if err != nil {
 		t.Fatalf("Client.GetAccessToken returns an error %v", err)
 	}

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -1,0 +1,88 @@
+package hipchat
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestGetAccessToken(t *testing.T) {
+	setup()
+	defer teardown()
+
+	clientID := "client-abcdef"
+	clientSecret := "secret-12345"
+
+	mux.HandleFunc("/oauth/token", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.String() != "/oauth/token" {
+			t.Errorf("Incorrect URL = %v, want %v", r.URL, "/oauth/token")
+		}
+
+		if m := "POST"; m != r.Method {
+			t.Errorf("Request method = %v, want %v", r.Method, m)
+		}
+
+		if r.Header.Get("Authorization") != "Basic Y2xpZW50LWFiY2RlZjpzZWNyZXQtMTIzNDU=" {
+			t.Errorf("Incorrect authorization header")
+		}
+
+		if r.FormValue("grant_type") != "client_credentials" {
+			t.Errorf("grant_type should be 'client_credentials'")
+		}
+
+		if r.FormValue("scopes") != "send_notification view_room" {
+			t.Errorf("scopes should be 'send_notification view_room'")
+		}
+
+		fmt.Fprintf(w, `
+		{
+            "access_token": "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",
+            "expires_in": 3599,
+            "group_id": 123456,
+            "group_name": "TestGroup",
+            "scope": "send_notification view_room",
+            "token_type": "bearer"
+        }
+        `)
+	})
+	want := &OAuthAccessToken{
+		AccessToken: "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",
+		ExpiresIn:   3599,
+		GroupID:     123456,
+		GroupName:   "TestGroup",
+		Scope:       "send_notification view_room",
+		TokenType:   "bearer",
+	}
+
+	credentials := ClientCredentials{ClientID: clientID, ClientSecret: clientSecret}
+
+	token, _, err := client.GetAccessToken(credentials, []string{"send_notification", "view_room"})
+	if err != nil {
+		t.Fatalf("Client.GetAccessToken returns an error %v", err)
+	}
+	if !reflect.DeepEqual(want, token) {
+		t.Errorf("Client.GetAccessToken returned %+v, want %+v", token, want)
+	}
+}
+
+func TestCreateClientFromAccessToken(t *testing.T) {
+	token := OAuthAccessToken{
+		AccessToken: "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",
+		ExpiresIn:   3599,
+		GroupID:     123456,
+		GroupName:   "TestGroup",
+		Scope:       "send_notification view_room",
+		TokenType:   "bearer",
+	}
+
+	client := token.CreateClient()
+
+	if client.authToken != token.AccessToken {
+		t.Fatalf(
+			"Client auth token does not match access token: %v != %v",
+			client.authToken,
+			token.AccessToken,
+		)
+	}
+}


### PR DESCRIPTION
Hipchat integrations typically work by issuing an OAuth client ID and client secret for each installation of the integration. The consumer can then make a call to Hipchat's OAuth2 token endpoint to get an access token that can be used in API requests.

For more information on integrations and grant_type=client_credentials: [see the Hipchat integration docs](https://www.hipchat.com/docs/apiv2/addons) and the [Hipchat API authentication docs](https://www.hipchat.com/docs/apiv2/auth)

This PR adds a way, given a set of client credentials, to request an access token.

```go
// Create an unauthenticated client
client := hipchat.NewClient("")

// Retrieve an access token using client credentials
token, _, _ := client.GetAccessToken(
	hipchat.ClientCredentials{ClientID: "12345", ClientSecret: "ABCDEF"},
	[]string{hipchat.ScopeSendNotification},
)

// Initialize a new authenticated client with the access token
client = token.CreateClient()

// Send the notification
message := &hipchat.NotificationRequest{Message: "This is a test message!!"}
client.Room.Notification(fmt.Sprintf("%d", install.RoomID), message)
```