### PR TITLE
Upgrade Travis CI config to use containerized infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
+sudo: false
 go:
          - 1.1
          - 1.2


### PR DESCRIPTION
Travis CI now has the ability to use containerized infrastructure. All that has to be done to use the new infrastructure is add "sudo: false" to the Travis configuration. For more information: http://docs.travis-ci.com/user/migrating-from-legacy/
