### PR TITLE
Store authToken in Client after generation

### DIFF
--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -74,6 +74,7 @@ func (c *Client) GenerateToken(credentials ClientCredentials, scopes []string) (
 
 	var token OAuthAccessToken
 	json.Unmarshal(content, &token)
+	c.authToken = token.AccessToken
 
 	return &token, resp, nil
 }


### PR DESCRIPTION
Since the method has already a reference to the Client, we can immediately store the AccessToken there.