### PR TITLE
Refactor how query parameters are passed to API methods (breaking changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.swp
+examples/hiptest

--- a/hipchat/emoticon.go
+++ b/hipchat/emoticon.go
@@ -1,7 +1,6 @@
 package hipchat
 
 import (
-	"fmt"
 	"net/http"
 )
 
@@ -26,12 +25,20 @@ type Emoticon struct {
 	Shortcut string `json:"shortcut"`
 }
 
+// EmoticonsListOptions specifies the optionnal parameters of the EmoticonService.List
+// method.
+type EmoticonsListOptions struct {
+	ListOptions
+
+	// The type of emoticons to get (global, group or all)
+	Type string `url:"type,omitempty"`
+}
+
 // List returns the list of all the emoticons
 //
 // HipChat api docs : https://www.hipchat.com/docs/apiv2/method/get_all_emoticons
-func (e *EmoticonService) List(start, max int, typee string) (*Emoticons, *http.Response, error) {
-	req, err := e.client.NewRequest("GET",
-		fmt.Sprintf("emoticon?start-index=%d&max-results=%d&type=%s", start, max, typee), nil)
+func (e *EmoticonService) List(opt *EmoticonsListOptions) (*Emoticons, *http.Response, error) {
+	req, err := e.client.NewRequest("GET", "emoticon", opt, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hipchat/emoticon_test.go
+++ b/hipchat/emoticon_test.go
@@ -12,15 +12,12 @@ func TestEmoticonList(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/emoticon", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
-		params := map[string]string{"start-index": "0", "max-results": "100", "type": "all"}
-		for k, v := range params {
-			if v != r.FormValue(k) {
-				t.Errorf("Request query params %s=%s, want %s", k, r.FormValue(k), v)
-			}
-		}
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"start-index": "1",
+			"max-results": "100",
+			"type":        "type",
+		})
 		fmt.Fprintf(w, `{
 			"items": [{"id":1, "url":"u", "shortcut":"s", "links":{"self":"s"}}],
 			"startIndex": 1,
@@ -35,7 +32,8 @@ func TestEmoticonList(t *testing.T) {
 		Links:      PageLinks{Links: Links{Self: "s"}, Prev: "p", Next: "n"},
 	}
 
-	emos, _, err := client.Emoticon.List(0, 100, "all")
+	opt := &EmoticonsListOptions{ListOptions{1, 100}, "type"}
+	emos, _, err := client.Emoticon.List(opt)
 	if err != nil {
 		t.Fatalf("Emoticon.List returned an error %v", err)
 	}

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -19,22 +19,13 @@ func TestGetAccessToken(t *testing.T) {
 			t.Errorf("Incorrect URL = %v, want %v", r.URL, "/oauth/token")
 		}
 
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "POST")
+		testHeader(t, r, "Authorization", "Basic Y2xpZW50LWFiY2RlZjpzZWNyZXQtMTIzNDU=")
+		testFormValues(t, r, values{
 
-		if r.Header.Get("Authorization") != "Basic Y2xpZW50LWFiY2RlZjpzZWNyZXQtMTIzNDU=" {
-			t.Errorf("Incorrect authorization header")
-		}
-
-		if r.FormValue("grant_type") != "client_credentials" {
-			t.Errorf("grant_type should be 'client_credentials'")
-		}
-
-		if r.FormValue("scope") != "send_notification view_room" {
-			t.Errorf("scope should be 'send_notification view_room'")
-		}
-
+			"grant_type": "client_credentials",
+			"scope":      "send_notification view_room",
+		})
 		fmt.Fprintf(w, `
 		{
             "access_token": "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",

--- a/hipchat/room_webhook.go
+++ b/hipchat/room_webhook.go
@@ -5,8 +5,6 @@ package hipchat
 import (
 	"fmt"
 	"net/http"
-	"net/url"
-	"strconv"
 )
 
 // Response Types
@@ -31,10 +29,9 @@ type WebhookList struct {
 
 // Request Types
 
-// ListWebhooksRequest represents options for ListWebhooks method.
-type ListWebhooksRequest struct {
-	MaxResults int
-	StartIndex int
+// ListWebhooksOptions represents options for ListWebhooks method.
+type ListWebhooksOptions struct {
+	ListOptions
 }
 
 // CreateWebhookRequest represents the body of the CreateWebhook method.
@@ -48,21 +45,9 @@ type CreateWebhookRequest struct {
 // ListWebhooks returns all the webhooks for a given room.
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/get_all_webhooks
-func (r *RoomService) ListWebhooks(id interface{}, roomReq *ListWebhooksRequest) (*WebhookList, *http.Response, error) {
+func (r *RoomService) ListWebhooks(id interface{}, opt *ListWebhooksOptions) (*WebhookList, *http.Response, error) {
 	u := fmt.Sprintf("room/%v/webhook", id)
-	if roomReq != nil {
-		p := url.Values{}
-		if roomReq.MaxResults != 0 {
-			p.Add("max-results", strconv.FormatInt(int64(roomReq.MaxResults), 10))
-		}
-		if roomReq.StartIndex != 0 {
-			p.Add("start-index", strconv.FormatInt(int64(roomReq.StartIndex), 10))
-		}
-		if len(p) > 0 {
-			u += "?" + p.Encode()
-		}
-	}
-	req, err := r.client.NewRequest("GET", u, nil)
+	req, err := r.client.NewRequest("GET", u, opt, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -79,7 +64,7 @@ func (r *RoomService) ListWebhooks(id interface{}, roomReq *ListWebhooksRequest)
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/delete_webhook
 func (r *RoomService) DeleteWebhook(id interface{}, webhookID interface{}) (*http.Response, error) {
-	req, err := r.client.NewRequest("DELETE", fmt.Sprintf("room/%v/webhook/%v", id, webhookID), nil)
+	req, err := r.client.NewRequest("DELETE", fmt.Sprintf("room/%v/webhook/%v", id, webhookID), nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +81,7 @@ func (r *RoomService) DeleteWebhook(id interface{}, webhookID interface{}) (*htt
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/create_webhook
 func (r *RoomService) CreateWebhook(id interface{}, roomReq *CreateWebhookRequest) (*Webhook, *http.Response, error) {
-	req, err := r.client.NewRequest("POST", fmt.Sprintf("room/%v/webhook", id), roomReq)
+	req, err := r.client.NewRequest("POST", fmt.Sprintf("room/%v/webhook", id), nil, roomReq)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/hipchat/room_webhook_test.go
+++ b/hipchat/room_webhook_test.go
@@ -13,9 +13,11 @@ func TestWebhookList(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/room/1/webhook", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method = %v, want %v", r.Method, m)
-		}
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"max-results": "100",
+			"start-index": "1",
+		})
 		fmt.Fprintf(w, `
 		{
 			"items":[
@@ -52,9 +54,9 @@ func TestWebhookList(t *testing.T) {
 		Links:      PageLinks{Links: Links{Self: "s"}, Prev: "a", Next: "b"},
 	}
 
-	reqParams := &ListWebhooksRequest{}
+	opt := &ListWebhooksOptions{ListOptions{1, 100}}
 
-	actual, _, err := client.Room.ListWebhooks("1", reqParams)
+	actual, _, err := client.Room.ListWebhooks("1", opt)
 	if err != nil {
 		t.Fatalf("Room.ListWebhooks returns an error %v", err)
 	}
@@ -68,9 +70,7 @@ func TestWebhookDelete(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/room/1/webhook/2", func(w http.ResponseWriter, r *http.Request) {
-		if m := "DELETE"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
+		testMethod(t, r, "DELETE")
 	})
 
 	_, err := client.Room.DeleteWebhook("1", "2")

--- a/hipchat/user.go
+++ b/hipchat/user.go
@@ -68,7 +68,7 @@ func (u *UserService) ShareFile(id string, shareFileReq *ShareFileRequest) (*htt
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/view_user
 func (u *UserService) View(id string) (*User, *http.Response, error) {
-	req, err := u.client.NewRequest("GET", fmt.Sprintf("user/%s", id), nil)
+	req, err := u.client.NewRequest("GET", fmt.Sprintf("user/%s", id), nil, nil)
 
 	userDetails := new(User)
 	resp, err := u.client.Do(req, &userDetails)
@@ -82,7 +82,7 @@ func (u *UserService) View(id string) (*User, *http.Response, error) {
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/private_message_user
 func (u *UserService) Message(id string, msgReq *MessageRequest) (*http.Response, error) {
-	req, err := u.client.NewRequest("POST", fmt.Sprintf("user/%s/message", id), msgReq)
+	req, err := u.client.NewRequest("POST", fmt.Sprintf("user/%s/message", id), nil, msgReq)
 	if err != nil {
 		return nil, err
 	}
@@ -90,14 +90,20 @@ func (u *UserService) Message(id string, msgReq *MessageRequest) (*http.Response
 	return u.client.Do(req, nil)
 }
 
+// UserListOptions specified the parameters to the UserService.List method.
+type UserListOptions struct {
+	ListOptions
+	// Include active guest users in response.
+	IncludeGuests bool `url:"include-guests,omitempty"`
+	// Include deleted users in response.
+	IncludeDeleted bool `url:"include-deleted,omitempty"`
+}
+
 // List returns all users in the group.
 //
 // HipChat API docs: https://www.hipchat.com/docs/apiv2/method/get_all_users
-func (u *UserService) List(start, max int, guests, deleted bool) ([]User, *http.Response, error) {
-	if max == 0 {
-		max = 100
-	}
-	req, err := u.client.NewRequest("GET", fmt.Sprintf("user?start-index=%d&max-results=%d&include-guests=%v&include-deleted=%v", start, max, guests, deleted), nil)
+func (u *UserService) List(opt *UserListOptions) ([]User, *http.Response, error) {
+	req, err := u.client.NewRequest("GET", "user", opt, nil)
 
 	users := new(Users)
 	resp, err := u.client.Do(req, &users)

--- a/hipchat/user_test.go
+++ b/hipchat/user_test.go
@@ -30,9 +30,7 @@ func TestUserShareFile(t *testing.T) {
 		"--hipfileboundary\n"
 
 	mux.HandleFunc("/user/1/share/file", func(w http.ResponseWriter, r *http.Request) {
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
+		testMethod(t, r, "POST")
 
 		body, _ := ioutil.ReadAll(r.Body)
 
@@ -56,9 +54,7 @@ func TestUserMessage(t *testing.T) {
 	args := &MessageRequest{Message: "m", MessageFormat: "text"}
 
 	mux.HandleFunc("/user/@FirstL/message", func(w http.ResponseWriter, r *http.Request) {
-		if m := "POST"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
+		testMethod(t, r, "POST")
 		v := new(MessageRequest)
 		json.NewDecoder(r.Body).Decode(v)
 
@@ -79,9 +75,7 @@ func TestUserView(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/user/@FirstL", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
+		testMethod(t, r, "GET")
 		fmt.Fprintf(w, `
 			{
 				"created": "2013-11-07T17:57:11+00:00",
@@ -147,9 +141,13 @@ func TestUserList(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
-		if m := "GET"; m != r.Method {
-			t.Errorf("Request method %s, want %s", r.Method, m)
-		}
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"start-index":     "1",
+			"max-results":     "100",
+			"include-guests":  "true",
+			"include-deleted": "true",
+		})
 		fmt.Fprintf(w, `
             {
               "items": [
@@ -178,7 +176,12 @@ func TestUserList(t *testing.T) {
 		},
 	}
 
-	users, _, err := client.User.List(0, 100, false, false)
+	opt := &UserListOptions{
+		ListOptions{StartIndex: 1, MaxResults: 100},
+		true, true,
+	}
+
+	users, _, err := client.User.List(opt)
 	if err != nil {
 		t.Fatalf("User.List returned an error %v", err)
 	}


### PR DESCRIPTION
All query parameters are now passed to the API methods with a struct suffixed with the `Options` name. This struct is tagged with the `url` tag for each field, in order to configure the query parameter names.
This kind of struct already existed but they were badly named with the `Request` prefix and tagged with `json` whereas they were never encoded to json. 

The `client.NewRequest` method receives a new parameter for this struct, and use it to create the parameter list.

This PR is created for the record and will be merged in a few days.