### PR TITLE
Add From field to NotificationRequest struct.

### DIFF
--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -73,6 +73,7 @@ type NotificationRequest struct {
 	Message       string `json:"message,omitempty"`
 	Notify        bool   `json:"notify,omitempty"`
 	MessageFormat string `json:"message_format,omitempty"`
+	From          string `json:"from,omitempty"`
 }
 
 // ShareFileRequest represents a HipChat room file share request.


### PR DESCRIPTION
Hey @tbruyelle! While using the `NotificationRequest` struct from your library, I noticed that there was no support for the `from` parameter supported by the `send_room_notification` API endpoint:

https://www.hipchat.com/docs/apiv2/method/send_room_notification

Thus, the purpose of this PR is to add the `From` field to the `NotificationRequest` struct.