### PR TITLE
Add SetHTTPClient method to hipchat.Client

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -93,6 +93,16 @@ func NewClient(authToken string) *Client {
 	return c
 }
 
+// SetHTTPClient sets the HTTP client for performing API requests.
+// If a nil httpClient is provided, http.DefaultClient will be used.
+func (c *Client) SetHTTPClient(httpClient *http.Client) {
+	if httpClient == nil {
+		c.client = http.DefaultClient
+	} else {
+		c.client = httpClient
+	}
+}
+
 // NewRequest creates an API request. This method can be used to performs
 // API request not implemented in this library. Otherwise it should not be
 // be used directly.

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -73,6 +73,30 @@ func TestNewClient(t *testing.T) {
 	if c.BaseURL.String() != defaultBaseURL {
 		t.Errorf("NewClient BaseURL %s, want %s", c.BaseURL.String(), defaultBaseURL)
 	}
+	if c.client != http.DefaultClient {
+		t.Errorf("SetHTTPClient client %p, want %p", c.client, http.DefaultClient)
+	}
+}
+
+func TestSetHTTPClient(t *testing.T) {
+	c := NewClient("AuthToken")
+
+	httpClient := new(http.Client)
+	c.SetHTTPClient(httpClient)
+
+	if c.client != httpClient {
+		t.Errorf("SetHTTPClient client %p, want %p", c.client, httpClient)
+	}
+}
+
+func TestSetHTTPClient_NilHTTPClient(t *testing.T) {
+	c := NewClient("AuthToken")
+
+	c.SetHTTPClient(nil)
+
+	if c.client != http.DefaultClient {
+		t.Errorf("SetHTTPClient client %p, want %p", c.client, http.DefaultClient)
+	}
 }
 
 func TestNewRequest(t *testing.T) {


### PR DESCRIPTION
As discussed in #29, I have added `SetHTTPClient` method to `hipchat.Client`.