### PR TITLE
Support for hipchat server URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ go:
 install: go get -v ./hipchat
 script:
     - go get -u github.com/golang/lint/golint
-    - golint ./...
+    - $GOPATH/bin/golint ./...
     - test `gofmt -l . | wc -l` = 0
     - make all
 

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -76,7 +76,7 @@ var AuthTestResponse = map[string]interface{}{}
 
 // NewClient returns a new HipChat API client. You must provide a valid
 // AuthToken retrieved from your HipChat account.
-func NewClient(authToken string) *Client {
+func NewClient(authToken string, options ...func(*Client) error) *Client {
 	baseURL, err := url.Parse(defaultBaseURL)
 	if err != nil {
 		panic(err)
@@ -87,10 +87,32 @@ func NewClient(authToken string) *Client {
 		BaseURL:   baseURL,
 		client:    http.DefaultClient,
 	}
+
+	// Option paremeters values:
+	for _, option := range options {
+		err := option(c)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	c.Room = &RoomService{client: c}
 	c.User = &UserService{client: c}
 	c.Emoticon = &EmoticonService{client: c}
 	return c
+}
+
+func OptionBaseUrl(baseUrl string) func(c *Client) error {
+	return func(c *Client) error {
+		parsedUrl, err := url.Parse(baseUrl)
+		if err != nil {
+			return err
+		}
+
+		c.BaseURL = parsedUrl
+		return nil
+	}
+
 }
 
 // SetHTTPClient sets the HTTP client for performing API requests.

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -102,14 +102,15 @@ func NewClient(authToken string, options ...func(*Client) error) *Client {
 	return c
 }
 
-func OptionBaseUrl(baseUrl string) func(c *Client) error {
+// OptionBaseURL sets a custom BaseURL. Use this if working with HipChat Server
+func OptionBaseURL(baseURL string) func(c *Client) error {
 	return func(c *Client) error {
-		parsedUrl, err := url.Parse(baseUrl)
+		parsedURL, err := url.Parse(baseURL)
 		if err != nil {
 			return err
 		}
 
-		c.BaseURL = parsedUrl
+		c.BaseURL = parsedURL
 		return nil
 	}
 

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -78,6 +78,23 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientCustomUrl(t *testing.T) {
+	authToken := "AuthToken"
+	nonDefaultUrl := "https://server.example.com/v2/"
+
+	c := NewClient(authToken, OptionBaseUrl(nonDefaultUrl))
+
+	if c.authToken != authToken {
+		t.Errorf("NewClient authToken %s, want %s", c.authToken, authToken)
+	}
+	if c.BaseURL.String() != nonDefaultUrl {
+		t.Errorf("NewClient BaseURL %s, want %s", c.BaseURL.String(), defaultBaseURL)
+	}
+	if c.client != http.DefaultClient {
+		t.Errorf("SetHTTPClient client %p, want %p", c.client, http.DefaultClient)
+	}
+}
+
 func TestSetHTTPClient(t *testing.T) {
 	c := NewClient("AuthToken")
 

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -80,14 +80,14 @@ func TestNewClient(t *testing.T) {
 
 func TestNewClientCustomUrl(t *testing.T) {
 	authToken := "AuthToken"
-	nonDefaultUrl := "https://server.example.com/v2/"
+	nonDefaultURL := "https://server.example.com/v2/"
 
-	c := NewClient(authToken, OptionBaseUrl(nonDefaultUrl))
+	c := NewClient(authToken, OptionBaseURL(nonDefaultURL))
 
 	if c.authToken != authToken {
 		t.Errorf("NewClient authToken %s, want %s", c.authToken, authToken)
 	}
-	if c.BaseURL.String() != nonDefaultUrl {
+	if c.BaseURL.String() != nonDefaultURL {
 		t.Errorf("NewClient BaseURL %s, want %s", c.BaseURL.String(), defaultBaseURL)
 	}
 	if c.client != http.DefaultClient {

--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -23,11 +23,12 @@ type OAuthAccessToken struct {
 	GroupName   string `json:"group_name"`
 	Scope       string `json:"scope"`
 	TokenType   string `json:"token_type"`
+	BaseURL     *url.URL
 }
 
 // CreateClient creates a new client from this OAuth token
 func (t *OAuthAccessToken) CreateClient() *Client {
-	return NewClient(t.AccessToken)
+	return NewClient(t.AccessToken, OptionBaseUrl(t.BaseURL.String()))
 }
 
 // GenerateToken returns back an access token for a given integration's client ID and client secret
@@ -74,7 +75,7 @@ func (c *Client) GenerateToken(credentials ClientCredentials, scopes []string) (
 
 	var token OAuthAccessToken
 	json.Unmarshal(content, &token)
-
+	token.BaseURL = c.BaseURL
 	return &token, resp, nil
 }
 

--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -28,7 +28,7 @@ type OAuthAccessToken struct {
 
 // CreateClient creates a new client from this OAuth token
 func (t *OAuthAccessToken) CreateClient() *Client {
-	return NewClient(t.AccessToken, OptionBaseUrl(t.BaseURL.String()))
+	return NewClient(t.AccessToken, OptionBaseURL(t.BaseURL.String()))
 }
 
 // GenerateToken returns back an access token for a given integration's client ID and client secret

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -82,7 +82,7 @@ func TestCreateClientFromAccessToken(t *testing.T) {
 }
 
 func TestCreateClientFromAccessTokenWithCustomURL(t *testing.T) {
-	nonDefaultUrl, _ := url.Parse("https://server.example.com/v2/")
+	nonDefaultURL, _ := url.Parse("https://server.example.com/v2/")
 	token := OAuthAccessToken{
 		AccessToken: "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",
 		ExpiresIn:   3599,
@@ -90,7 +90,7 @@ func TestCreateClientFromAccessTokenWithCustomURL(t *testing.T) {
 		GroupName:   "TestGroup",
 		Scope:       "send_notification view_room",
 		TokenType:   "bearer",
-		BaseURL:     nonDefaultUrl,
+		BaseURL:     nonDefaultURL,
 	}
 
 	client := token.CreateClient()

--- a/hipchat/oauth_test.go
+++ b/hipchat/oauth_test.go
@@ -3,6 +3,7 @@ package hipchat
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"testing"
 )
@@ -44,6 +45,7 @@ func TestGetAccessToken(t *testing.T) {
 		GroupName:   "TestGroup",
 		Scope:       "send_notification view_room",
 		TokenType:   "bearer",
+		BaseURL:     client.BaseURL,
 	}
 
 	credentials := ClientCredentials{ClientID: clientID, ClientSecret: clientSecret}
@@ -65,6 +67,7 @@ func TestCreateClientFromAccessToken(t *testing.T) {
 		GroupName:   "TestGroup",
 		Scope:       "send_notification view_room",
 		TokenType:   "bearer",
+		BaseURL:     client.BaseURL,
 	}
 
 	client := token.CreateClient()
@@ -74,6 +77,37 @@ func TestCreateClientFromAccessToken(t *testing.T) {
 			"Client auth token does not match access token: %v != %v",
 			client.authToken,
 			token.AccessToken,
+		)
+	}
+}
+
+func TestCreateClientFromAccessTokenWithCustomURL(t *testing.T) {
+	nonDefaultUrl, _ := url.Parse("https://server.example.com/v2/")
+	token := OAuthAccessToken{
+		AccessToken: "q0M8p3UrBL96uHb79x4qdR2r6oEnCeajcg123456",
+		ExpiresIn:   3599,
+		GroupID:     123456,
+		GroupName:   "TestGroup",
+		Scope:       "send_notification view_room",
+		TokenType:   "bearer",
+		BaseURL:     nonDefaultUrl,
+	}
+
+	client := token.CreateClient()
+
+	if client.authToken != token.AccessToken {
+		t.Fatalf(
+			"Client auth token does not match access token: %v != %v",
+			client.authToken,
+			token.AccessToken,
+		)
+	}
+
+	if client.BaseURL.String() != token.BaseURL.String() {
+		t.Fatalf(
+			"Client base url not match access token: %v != %v",
+			client.BaseURL,
+			token.BaseURL,
 		)
 	}
 }


### PR DESCRIPTION
I was trying to build an addon that's compatible with hipchat server, ended up implementing this. The idea is to make this completely optional, but to also have the tokens created from a client 'inherit' the url. Then, you can do something like this:

```go
newClient := hipchat.NewClient("", hipchat.OptionBaseUrl("https://hipchat.example.com/v2"))
token, _, err := newClient.GenerateToken(
					credentials,
					[]string{hipchat.ScopeManageRooms, hipchat.ScopeViewGroup, hipchat.ScopeSendNotification, hipchat.ScopeAdminRoom})

client := token.CreateClient()
```

And the resulting client will be able to auth with the server. 