### PR TITLE
Add `Key` field to webhooks, and request options

### DIFF
--- a/hipchat/room_webhook.go
+++ b/hipchat/room_webhook.go
@@ -13,6 +13,7 @@ import (
 type Webhook struct {
 	Links   Links  `json:"links"`
 	Name    string `json:"name"`
+	Key     string `json:"key,omitempty"`
 	Event   string `json:"event"`
 	Pattern string `json:"pattern"`
 	URL     string `json:"url"`
@@ -37,6 +38,7 @@ type ListWebhooksOptions struct {
 // CreateWebhookRequest represents the body of the CreateWebhook method.
 type CreateWebhookRequest struct {
 	Name    string `json:"name"`
+	Key     string `json:"key,omitempty"`
 	Event   string `json:"event"`
 	Pattern string `json:"pattern"`
 	URL     string `json:"url"`

--- a/hipchat/room_webhook_test.go
+++ b/hipchat/room_webhook_test.go
@@ -21,8 +21,8 @@ func TestWebhookList(t *testing.T) {
 		fmt.Fprintf(w, `
 		{
 			"items":[
-			  {"name":"a", "pattern":"a", "event":"message_received", "url":"h", "id":1, "links":{"self":"s"}},
-				{"name":"b", "pattern":"b", "event":"message_received", "url":"h", "id":2, "links":{"self":"s"}}
+			  {"name":"a", "key": "a", "pattern":"a", "event":"message_received", "url":"h", "id":1, "links":{"self":"s"}},
+				{"name":"b", "key": "b", "pattern":"b", "event":"message_received", "url":"h", "id":2, "links":{"self":"s"}}
 			],
 			"links":{"self":"s", "prev":"a", "next":"b"},
 			"startIndex":0,
@@ -34,6 +34,7 @@ func TestWebhookList(t *testing.T) {
 		Webhooks: []Webhook{
 			{
 				Name:    "a",
+				Key:     "a",
 				Pattern: "a",
 				Event:   "message_received",
 				URL:     "h",
@@ -42,6 +43,7 @@ func TestWebhookList(t *testing.T) {
 			},
 			{
 				Name:    "b",
+				Key:     "b",
 				Pattern: "b",
 				Event:   "message_received",
 				URL:     "h",


### PR DESCRIPTION
Pretty small, and self-explanatory.

From the [docs](https://www.hipchat.com/docs/apiv2/method/create_webhook):

Type | Property | Description
--- | --- | ---
STRING | `key` | Unique key (in the context of the integration) to identify this webhook. Valid length range: 1 - 40.
