### PR TITLE
Do not create a new httpclient but use the one set in hipchatclient.

### DIFF
--- a/hipchat/oauth.go
+++ b/hipchat/oauth.go
@@ -53,8 +53,7 @@ func (c *Client) GenerateToken(credentials ClientCredentials, scopes []string) (
 	req.SetBasicAuth(credentials.ClientID, credentials.ClientSecret)
 	req.Header.Set("Content-type", "application/x-www-form-urlencoded")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := c.client.Do(req)
 
 	if err != nil {
 		return nil, resp, err


### PR DESCRIPTION
Fixed the only place where hipchatclient.client was not used.
For us this fixed a bug where the specified proxy was not allways used.