### PR TITLE
Use an interface so non-default http clients can be used.

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -111,7 +111,10 @@ func NewClient(authToken string) *Client {
 	return c
 }
 
-// SetHTTPClient sets the HTTP client for performing API requests.
+// SetHTTPClient sets the http client for performing API requests.
+// This method allows overriding the default http client with any
+// implementation of the HTTPClient interface. It is typically used
+// to have finer control of the http request.
 // If a nil httpClient is provided, http.DefaultClient will be used.
 func (c *Client) SetHTTPClient(httpClient HTTPClient) {
 	if httpClient == nil {

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -26,11 +26,17 @@ const (
 	defaultBaseURL = "https://api.hipchat.com/v2/"
 )
 
+// HTTPClient is an interface that allows overriding the http behavior
+// by providing custom http clients
+type HTTPClient interface {
+	Do(req *http.Request) (res *http.Response, err error)
+}
+
 // Client manages the communication with the HipChat API.
 type Client struct {
 	authToken string
 	BaseURL   *url.URL
-	client    *http.Client
+	client    HTTPClient
 	// Room gives access to the /room part of the API.
 	Room *RoomService
 	// User gives access to the /user part of the API.
@@ -107,7 +113,7 @@ func NewClient(authToken string) *Client {
 
 // SetHTTPClient sets the HTTP client for performing API requests.
 // If a nil httpClient is provided, http.DefaultClient will be used.
-func (c *Client) SetHTTPClient(httpClient *http.Client) {
+func (c *Client) SetHTTPClient(httpClient HTTPClient) {
 	if httpClient == nil {
 		c.client = http.DefaultClient
 	} else {

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -74,7 +74,7 @@ func TestNewClient(t *testing.T) {
 		t.Errorf("NewClient BaseURL %s, want %s", c.BaseURL.String(), defaultBaseURL)
 	}
 	if c.client != http.DefaultClient {
-		t.Errorf("SetHTTPClient client %p, want %p", c.client, http.DefaultClient)
+		t.Errorf("SetHTTPClient client %v, want %p", c.client, http.DefaultClient)
 	}
 }
 
@@ -85,7 +85,24 @@ func TestSetHTTPClient(t *testing.T) {
 	c.SetHTTPClient(httpClient)
 
 	if c.client != httpClient {
-		t.Errorf("SetHTTPClient client %p, want %p", c.client, httpClient)
+		t.Errorf("SetHTTPClient client %v, want %p", c.client, httpClient)
+	}
+}
+
+type customHTTPClient struct{}
+
+func (c customHTTPClient) Do(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestSetCustomHTTPClient(t *testing.T) {
+	c := NewClient("AuthToken")
+
+	httpClient := new(customHTTPClient)
+	c.SetHTTPClient(httpClient)
+
+	if c.client != httpClient {
+		t.Errorf("SetHTTPClient client %v, want %p", c.client, httpClient)
 	}
 }
 
@@ -95,7 +112,7 @@ func TestSetHTTPClient_NilHTTPClient(t *testing.T) {
 	c.SetHTTPClient(nil)
 
 	if c.client != http.DefaultClient {
-		t.Errorf("SetHTTPClient client %p, want %p", c.client, http.DefaultClient)
+		t.Errorf("SetHTTPClient client %v, want %p", c.client, http.DefaultClient)
 	}
 }
 


### PR DESCRIPTION
This is to enable users to plug in other http-like clients (e.g https://github.com/sethgrid/pester)

```
client := token.CreateClient()
client.BaseURL = baseURL

httpClient := pester.New()
httpClient.MaxRetries = 10
httpClient.Backoff = pester.ExponentialJitterBackoff
httpClient.KeepLog = true
client.SetHTTPClient(httpClient)
```