### PR TITLE
Fix lint errors

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -72,14 +72,22 @@ type ListOptions struct {
 	MaxResults int `url:"max-results,omitempty"`
 }
 
+// Color is set of hard-coded string values for the HipChat API for notifications.
+// cf: https://www.hipchat.com/docs/apiv2/method/send_room_notification
 type Color string
 
 const (
+	// ColorYellow is the color yellow
 	ColorYellow Color = "yellow"
+	// ColorGreen is the color green
 	ColorGreen  Color = "green"
+	// ColorRed is the color red
 	ColorRed    Color = "red"
+	// ColorPurple is the color purple
 	ColorPurple Color = "purple"
+	// ColorGray is the color gray
 	ColorGray   Color = "gray"
+	// ColorRandom is the random "surprise me!" color
 	ColorRandom Color = "random"
 )
 

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -80,13 +80,13 @@ const (
 	// ColorYellow is the color yellow
 	ColorYellow Color = "yellow"
 	// ColorGreen is the color green
-	ColorGreen  Color = "green"
+	ColorGreen Color = "green"
 	// ColorRed is the color red
-	ColorRed    Color = "red"
+	ColorRed Color = "red"
 	// ColorPurple is the color purple
 	ColorPurple Color = "purple"
 	// ColorGray is the color gray
-	ColorGray   Color = "gray"
+	ColorGray Color = "gray"
 	// ColorRandom is the random "surprise me!" color
 	ColorRandom Color = "random"
 )

--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -25,7 +25,7 @@ type Room struct {
 	ID                int            `json:"id"`
 	Links             RoomLinks      `json:"links"`
 	Name              string         `json:"name"`
-	XmppJid           string         `json:"xmpp_jid"`
+	XMPPJid           string         `json:"xmpp_jid"`
 	Statistics        RoomStatistics `json:"statistics"`
 	Created           string         `json:"created"`
 	IsArchived        bool           `json:"is_archived"`

--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -511,6 +511,14 @@ type HistoryOptions struct {
 	// Reverse the output such that the oldest message is first.
 	// For consistent paging, set to 'false'.
 	Reverse bool `url:"reverse,omitempty"`
+
+	// Either the earliest date to fetch history for the ISO-8601 format string,
+	// or 'null' to disable this filter.
+	// to be effective, API call requires Date also be filled in with an ISO-8601 format string.
+	EndDate string `url:"end-date,omitempty"`
+
+	// Include records about deleted messages into results (body of a message isn't returned).  Set to 'true'.
+	IncludeDeleted bool `url:"include_deleted,omitempty"`
 }
 
 // History fetches a room's chat history.

--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -513,8 +513,8 @@ type HistoryOptions struct {
 	Reverse bool `url:"reverse,omitempty"`
 
 	// Either the earliest date to fetch history for the ISO-8601 format string,
-	// or 'null' to disable this filter.
-	// to be effective, API call requires Date also be filled in with an ISO-8601 format string.
+	// or leave blank to disable this filter.
+	// to be effective, the API call requires Date also be filled in with an ISO-8601 format string.
 	EndDate string `url:"end-date,omitempty"`
 
 	// Include records about deleted messages into results (body of a message isn't returned).  Set to 'true'.

--- a/hipchat/room_test.go
+++ b/hipchat/room_test.go
@@ -255,11 +255,13 @@ func TestRoomHistory(t *testing.T) {
 	mux.HandleFunc("/room/1/history", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
-			"start-index": "1",
-			"max-results": "100",
-			"date":        "date",
-			"timezone":    "tz",
-			"reverse":     "true",
+			"start-index":     "1",
+			"max-results":     "100",
+			"date":            "date",
+			"timezone":        "tz",
+			"reverse":         "true",
+			"end-date":        "end-date",
+			"include_deleted": "true",
 		})
 		fmt.Fprintf(w, `
 		{
@@ -283,7 +285,7 @@ func TestRoomHistory(t *testing.T) {
 	})
 
 	opt := &HistoryOptions{
-		ListOptions{1, 100}, "date", "tz", true,
+		ListOptions{1, 100}, "date", "tz", true, "end-date", true,
 	}
 	hist, _, err := client.Room.History("1", opt)
 	if err != nil {

--- a/hipchat/user.go
+++ b/hipchat/user.go
@@ -50,7 +50,7 @@ type UpdateUserPresenceRequest struct {
 
 // User represents the HipChat user.
 type User struct {
-	XmppJid      string       `json:"xmpp_jid"`
+	XMPPJid      string       `json:"xmpp_jid"`
 	IsDeleted    bool         `json:"is_deleted"`
 	Name         string       `json:"name"`
 	LastActive   string       `json:"last_active"`

--- a/hipchat/user_test.go
+++ b/hipchat/user_test.go
@@ -111,7 +111,7 @@ func TestUserView(t *testing.T) {
 				"xmpp_jid": "1@chat.hipchat.com"
 			}`)
 	})
-	want := &User{XmppJid: "1@chat.hipchat.com",
+	want := &User{XMPPJid: "1@chat.hipchat.com",
 		IsDeleted:    false,
 		Name:         "First Last",
 		LastActive:   "1421029691",


### PR DESCRIPTION
**BREAKING CHANGE**
Field `XmppJid` renamed to `XMPPJid` per golint standards
