### PR TITLE
Implemented API title expansion

### DIFF
--- a/hipchat/emoticon_test.go
+++ b/hipchat/emoticon_test.go
@@ -32,7 +32,7 @@ func TestEmoticonList(t *testing.T) {
 		Links:      PageLinks{Links: Links{Self: "s"}, Prev: "p", Next: "n"},
 	}
 
-	opt := &EmoticonsListOptions{ListOptions{1, 100}, "type"}
+	opt := &EmoticonsListOptions{ListOptions{StartIndex: 1, MaxResults: 100}, "type"}
 	emos, _, err := client.Emoticon.List(opt)
 	if err != nil {
 		t.Fatalf("Emoticon.List returned an error %v", err)

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -63,6 +63,13 @@ type ID struct {
 	ID string `json:"id"`
 }
 
+// ExpandOptions represents a comma-separated list of API Title Expansions, as defined
+// at https://developer.atlassian.com/hipchat/guide/hipchat-rest-api/api-title-expansion
+// Example values might be "participants", or "items.statistics", or "modules,info"
+type ExpandOptions struct {
+	Expand string `url:"expand,omitempty"`
+}
+
 // ListOptions  specifies the optional parameters to various List methods that
 // support pagination.
 type ListOptions struct {
@@ -70,6 +77,8 @@ type ListOptions struct {
 	StartIndex int `url:"start-index,omitempty"`
 	// For paginated results, reprensents the number of items per page.
 	MaxResults int `url:"max-results,omitempty"`
+	// Expand is valid on all List API calls
+	ExpandOptions
 }
 
 // Color is set of hard-coded string values for the HipChat API for notifications.

--- a/hipchat/hipchat_test.go
+++ b/hipchat/hipchat_test.go
@@ -119,8 +119,8 @@ func TestSetHTTPClient_NilHTTPClient(t *testing.T) {
 func TestNewRequest(t *testing.T) {
 	c := NewClient("AuthToken")
 
-	inURL, outURL := "foo", defaultBaseURL+"foo?max-results=100&start-index=1"
-	opt := &ListOptions{StartIndex: 1, MaxResults: 100}
+	inURL, outURL := "foo", defaultBaseURL+"foo?expand=expansion&max-results=100&start-index=1"
+	opt := &ListOptions{ExpandOptions: ExpandOptions{Expand: "expansion"}, StartIndex: 1, MaxResults: 100}
 	inBody, outBody := &NotificationRequest{Message: "Hello"}, `{"message":"Hello"}`+"\n"
 	r, _ := c.NewRequest("GET", inURL, opt, inBody)
 

--- a/hipchat/room_test.go
+++ b/hipchat/room_test.go
@@ -66,7 +66,7 @@ func TestRoomList(t *testing.T) {
 		}`)
 	})
 	want := &Rooms{Items: []Room{{ID: 1, Name: "n"}}, StartIndex: 1, MaxResults: 1, Links: PageLinks{Links: Links{Self: "s"}}}
-	opt := &RoomsListOptions{ListOptions{1, 10}, true, true}
+	opt := &RoomsListOptions{ListOptions{StartIndex: 1, MaxResults: 10}, true, true}
 	rooms, _, err := client.Room.List(opt)
 	if err != nil {
 		t.Fatalf("Room.List returns an error %v", err)
@@ -285,7 +285,7 @@ func TestRoomHistory(t *testing.T) {
 	})
 
 	opt := &HistoryOptions{
-		ListOptions{1, 100}, "date", "tz", true, "end-date", true,
+		ListOptions{StartIndex: 1, MaxResults: 100}, "date", "tz", true, "end-date", true,
 	}
 	hist, _, err := client.Room.History("1", opt)
 	if err != nil {

--- a/hipchat/room_webhook_test.go
+++ b/hipchat/room_webhook_test.go
@@ -56,7 +56,7 @@ func TestWebhookList(t *testing.T) {
 		Links:      PageLinks{Links: Links{Self: "s"}, Prev: "a", Next: "b"},
 	}
 
-	opt := &ListWebhooksOptions{ListOptions{1, 100}}
+	opt := &ListWebhooksOptions{ListOptions{StartIndex: 1, MaxResults: 100}}
 
 	actual, _, err := client.Room.ListWebhooks("1", opt)
 	if err != nil {


### PR DESCRIPTION
Fixes #45 

**BREAKING CHANGE** ExpandOptions is required for all ListOptions that initialize themselves without using the named parameter idiom.

Recommended fix:  insert `StartIndex` and `MaxResults` before the fields.
