### PR TITLE
Implement API Title Expansion (2)

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -336,7 +336,7 @@ func (c *Client) doWithRetryPolicy(req *http.Request, policy RetryPolicy) (*http
 			return nil, err
 		}
 		c.captureRateLimits(resp)
-		if code := resp.StatusCode; code == http.StatusTooManyRequests {
+		if http.StatusTooManyRequests == resp.StatusCode {
 			if willContinue(currentTry, policy) {
 				doDelay(currentTry, policy)
 			}

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -371,6 +371,13 @@ func setIfPresent(src string, dest *int) {
 }
 
 func (c *Client) captureRateLimits(resp *http.Response) {
+	// BY DESIGN:
+	// if and only if the HTTP Response headers contain the header are the values updated.
+	// The Floodcontrol limits are orthogonal to the API limits.
+	// API Limits are consumed for each and every API call.
+	// The default value for API limits are 500 (app token) or 100 (user token).
+	// Flood Control limits are consumed only when a user message, room message, or room notification is sent.
+	// The default value for Flood Control limits is 30 per minute per user token.
 	setIfPresent(resp.Header.Get("X-Ratelimit-Limit"), &c.LatestRateLimit.Limit)
 	setIfPresent(resp.Header.Get("X-Ratelimit-Remaining"), &c.LatestRateLimit.Remaining)
 	setIfPresent(resp.Header.Get("X-Ratelimit-Reset"), &c.LatestRateLimit.ResetTime)

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -122,6 +122,7 @@ var AuthTestResponse = map[string]interface{}{}
 var RetryOnRateLimit = false
 
 // RetryPolicy defines a RetryPolicy.
+//
 type RetryPolicy struct {
 	// MaxRetries is the maximum number of attempts to make before returning an error
 	MaxRetries int
@@ -143,7 +144,7 @@ var DefaultRateLimitRetryPolicy = RetryPolicy{300, 1 * time.Second, 1 * time.Sec
 
 // RateLimitRetryPolicy can be set to a custom RetryPolicy's values,
 // or to one of the two predefined ones: NoRateLimitRetryPolicy or DefaultRateLimitRetryPolicy
-var RateLimitRetryPolicy = &DefaultRateLimitRetryPolicy
+var RateLimitRetryPolicy = DefaultRateLimitRetryPolicy
 
 // NewClient returns a new HipChat API client. You must provide a valid
 // AuthToken retrieved from your HipChat account.
@@ -294,12 +295,12 @@ func (c *Client) NewFileUploadRequest(method, urlStr string, v interface{}) (*ht
 // Do can be used to perform the request created with NewRequest, which
 // should be used only for API requests not implemented in this library.
 func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
-	var policy = RateLimitRetryPolicy
-	if policy == nil || !RetryOnRateLimit {
-		policy = &NoRateLimitRetryPolicy
+	var policy = NoRateLimitRetryPolicy
+	if !RetryOnRateLimit {
+		policy = RateLimitRetryPolicy
 	}
 
-	resp, err := c.doWithRetryPolicy(req, *policy)
+	resp, err := c.doWithRetryPolicy(req, policy)
 	if err != nil {
 		return nil, err
 	}

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -123,17 +123,27 @@ var RetryOnRateLimit = false
 
 // RetryPolicy defines a RetryPolicy.
 //
+// MaxRetries is the maximum number of attempts to make before returning an error
+// MinDelay is the initial delay between attempts.  This value is multiplied by the current attempt number.
+// MaxDelay is the largest delay between attempts.
+// JitterDelay is the amount of random jitter to add to the delay.
+// JitterBias is the amount of jitter to remove from the delay.
+//
+// The use of Jitter avoids inadvertant and undesirable synchronization of network
+// operations between otherwise unrelated clients.
+// cf: https://brooker.co.za/blog/2015/03/21/backoff.html and https://www.awsarchitectureblog.com/2015/03/backoff.html
+//
+// Using the values of JitterDelay = 250 milliseconds and a JitterBias of negative 125 milliseconds,
+// would result in a uniformly distributed Jitter between -125 and +125 milliseconds, centered
+// around the current trial Delay (between MinDelay and MaxDelay).
+//
+//
 type RetryPolicy struct {
-	// MaxRetries is the maximum number of attempts to make before returning an error
-	MaxRetries int
-	// MinDelay is the initial delay between attempts.  This value is multiplied by the current attempt number.
-	MinDelay time.Duration
-	// MaxDelay is the largest delay between attempts.
-	MaxDelay time.Duration
-	// JitterDelay is the amount of random jitter to add to the delay.
+	MaxRetries  int
+	MinDelay    time.Duration
+	MaxDelay    time.Duration
 	JitterDelay time.Duration
-	// JitterBias is the amount of jitter to remove from the delay.
-	JitterBias time.Duration
+	JitterBias  time.Duration
 }
 
 // NoRateLimitRetryPolicy defines the "never retry an API call" policy's values.

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -35,30 +35,32 @@ type HTTPClient interface {
 }
 
 // LimitData contains the latest Rate Limit or Flood Control data sent with every API call response.
+//
+// Limit is the number of API calls per period of time
+// Remaining is the current number of API calls that can be done before the ResetTime
+// ResetTime is the UTC time in Unix epoch format for when the full Limit of API calls will be restored.
 type LimitData struct {
-	// Limit is the number of API calls per period of time
-	Limit int
-	// Remaining is the current number of API calls that can be done before the ResetTime
+	Limit     int
 	Remaining int
-	// ResetTime is the UTC time in Unix epoch format for when the full Limit of API calls will be restored.
 	ResetTime int
 }
 
 // Client manages the communication with the HipChat API.
+//
+// LatestFloodControl contains the response from the latest API call's response headers X-Floodcontrol-{Limit, Remaining, ResetTime}
+// LatestRateLimit contains the response from the latest API call's response headers X-Ratelimit-{Limit, Remaining, ResetTime}
+// Room gives access to the /room part of the API.
+// User gives access to the /user part of the API.
+// Emoticon gives access to the /emoticon part of the API.
 type Client struct {
-	authToken string
-	BaseURL   *url.URL
-	client    HTTPClient
-	// LatestFloodControl contains the response from the latest API call's response headers X-Floodcontrol-{Limit, Remaining, ResetTime}
+	authToken          string
+	BaseURL            *url.URL
+	client             HTTPClient
 	LatestFloodControl LimitData
-	// LatestRateLimit contains the response from the latest API call's response headers X-Ratelimit-{Limit, Remaining, ResetTime}
-	LatestRateLimit LimitData
-	// Room gives access to the /room part of the API.
-	Room *RoomService
-	// User gives access to the /user part of the API.
-	User *UserService
-	// Emoticon gives access to the /emoticon part of the API.
-	Emoticon *EmoticonService
+	LatestRateLimit    LimitData
+	Room               *RoomService
+	User               *UserService
+	Emoticon           *EmoticonService
 }
 
 // Links represents the HipChat default links.
@@ -81,10 +83,11 @@ type ID struct {
 
 // ListOptions  specifies the optional parameters to various List methods that
 // support pagination.
+//
+// For paginated results, StartIndex represents the first page to display.
+// For paginated results, MaxResults reprensents the number of items per page.  Default value is 100.  Maximum value is 1000.
 type ListOptions struct {
-	// For paginated results, represents the first page to display.
 	StartIndex int `url:"start-index,omitempty"`
-	// For paginated results, reprensents the number of items per page.
 	MaxResults int `url:"max-results,omitempty"`
 }
 

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -49,9 +49,9 @@ type Client struct {
 	authToken string
 	BaseURL   *url.URL
 	client    HTTPClient
-	// LatestFloodControl, if non-nil, contains the response from the latest API call's response headers X-Floodcontrol-{Limit, Remaining, ResetTime}
+	// LatestFloodControl contains the response from the latest API call's response headers X-Floodcontrol-{Limit, Remaining, ResetTime}
 	LatestFloodControl LimitData
-	// LatestRateLimit, if non-nil, contains the response from the latest API call's response headers X-Ratelimit-{Limit, Remaining, ResetTime}
+	// LatestRateLimit contains the response from the latest API call's response headers X-Ratelimit-{Limit, Remaining, ResetTime}
 	LatestRateLimit LimitData
 	// Room gives access to the /room part of the API.
 	Room *RoomService
@@ -141,7 +141,8 @@ var NoRateLimitRetryPolicy = RetryPolicy{0, 1 * time.Second, 1 * time.Second, 50
 // DefaultRateLimitRetryPolicy defines the "up to 300 times, 1 second apart, randomly adding an additional up-to-500 milliseconds of delay" policy.
 var DefaultRateLimitRetryPolicy = RetryPolicy{300, 1 * time.Second, 1 * time.Second, 500 * time.Millisecond, 0 * time.Millisecond}
 
-// RateLimitRetryPolicy can be set to a custom RetryPolicy's values, or to one of the two defined ones: NoRateLimitRetryPolicy or DefaultRateLimitRetryPolicy
+// RateLimitRetryPolicy can be set to a custom RetryPolicy's values,
+// or to one of the two predefined ones: NoRateLimitRetryPolicy or DefaultRateLimitRetryPolicy
 var RateLimitRetryPolicy = &DefaultRateLimitRetryPolicy
 
 // NewClient returns a new HipChat API client. You must provide a valid

--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -81,7 +81,7 @@ type ID struct {
 	ID string `json:"id"`
 }
 
-// ListOptions  specifies the optional parameters to various List methods that
+// ListOptions specifies the optional parameters to various List methods that
 // support pagination.
 //
 // For paginated results, StartIndex represents the first page to display.
@@ -89,6 +89,15 @@ type ID struct {
 type ListOptions struct {
 	StartIndex int `url:"start-index,omitempty"`
 	MaxResults int `url:"max-results,omitempty"`
+}
+
+// ExpandOptions specifies which Hipchat collections to automatically expand.
+// This functionality is primarily used to reduce the total time to receive the data.
+// It also reduces the sheer number of API calls from 1+N, to 1.
+//
+// cf:  https://developer.atlassian.com/hipchat/guide/hipchat-rest-api/api-title-expansion
+type ExpandOptions struct {
+	Expand string `url:"expand,omitempty"`
 }
 
 // Color is set of hard-coded string values for the HipChat API for notifications.

--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -360,6 +360,7 @@ func (c *Card) AddAttribute(mainLabel, subLabel, url, iconURL string) {
 // method.
 type RoomsListOptions struct {
 	ListOptions
+	ExpandOptions
 
 	// Include private rooms in the result, API defaults to true
 	IncludePrivate bool `url:"include-private,omitempty"`
@@ -499,6 +500,7 @@ func (r *RoomService) Update(id string, roomReq *UpdateRoomRequest) (*http.Respo
 // HistoryOptions represents a HipChat room chat history request.
 type HistoryOptions struct {
 	ListOptions
+	ExpandOptions
 
 	// Either the latest date to fetch history for in ISO-8601 format, or 'recent' to fetch
 	// the latest 75 messages. Paging isn't supported for 'recent', however they are real-time

--- a/hipchat/room_test.go
+++ b/hipchat/room_test.go
@@ -54,6 +54,7 @@ func TestRoomList(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":      "1",
 			"max-results":      "10",
+			"expand":           "expansion",
 			"include-private":  "true",
 			"include-archived": "true",
 		})
@@ -66,7 +67,7 @@ func TestRoomList(t *testing.T) {
 		}`)
 	})
 	want := &Rooms{Items: []Room{{ID: 1, Name: "n"}}, StartIndex: 1, MaxResults: 1, Links: PageLinks{Links: Links{Self: "s"}}}
-	opt := &RoomsListOptions{ListOptions{1, 10}, true, true}
+	opt := &RoomsListOptions{ListOptions{1, 10}, ExpandOptions{"expansion"}, true, true}
 	rooms, _, err := client.Room.List(opt)
 	if err != nil {
 		t.Fatalf("Room.List returns an error %v", err)
@@ -257,6 +258,7 @@ func TestRoomHistory(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":     "1",
 			"max-results":     "100",
+			"expand":          "expansion",
 			"date":            "date",
 			"timezone":        "tz",
 			"reverse":         "true",
@@ -285,7 +287,7 @@ func TestRoomHistory(t *testing.T) {
 	})
 
 	opt := &HistoryOptions{
-		ListOptions{1, 100}, "date", "tz", true, "end-date", true,
+		ListOptions{1, 100}, ExpandOptions{"expansion"}, "date", "tz", true, "end-date", true,
 	}
 	hist, _, err := client.Room.History("1", opt)
 	if err != nil {

--- a/hipchat/user.go
+++ b/hipchat/user.go
@@ -121,6 +121,8 @@ func (u *UserService) Message(id string, msgReq *MessageRequest) (*http.Response
 // UserListOptions specified the parameters to the UserService.List method.
 type UserListOptions struct {
 	ListOptions
+	ExpandOptions
+
 	// Include active guest users in response.
 	IncludeGuests bool `url:"include-guests,omitempty"`
 	// Include deleted users in response.

--- a/hipchat/user_test.go
+++ b/hipchat/user_test.go
@@ -145,6 +145,7 @@ func TestUserList(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":     "1",
 			"max-results":     "100",
+			"expand":          "expansion",
 			"include-guests":  "true",
 			"include-deleted": "true",
 		})
@@ -178,6 +179,7 @@ func TestUserList(t *testing.T) {
 
 	opt := &UserListOptions{
 		ListOptions{StartIndex: 1, MaxResults: 100},
+		ExpandOptions{"expansion"},
 		true, true,
 	}
 


### PR DESCRIPTION
Fixes #45

**MINOR BREAKING CHANGE**:

The structures `RoomsListOptions`, `UserListOptions`, and `HistoryOptions` each have an additional member inserted named `ExpandOptions`.  If these were constructed using positional arguments instead of the named argument idiom, a default `ExpandOptions{}` will need to be inserted after the `ListOptions` to maintain the current behaviors.
