### PR TITLE
Implement API Title Expansion (3)

### DIFF
--- a/hipchat/hipchat.go
+++ b/hipchat/hipchat.go
@@ -81,7 +81,7 @@ type ID struct {
 	ID string `json:"id"`
 }
 
-// ListOptions  specifies the optional parameters to various List methods that
+// ListOptions specifies the optional parameters to various List methods that
 // support pagination.
 //
 // For paginated results, StartIndex represents the first page to display.
@@ -89,6 +89,15 @@ type ID struct {
 type ListOptions struct {
 	StartIndex int `url:"start-index,omitempty"`
 	MaxResults int `url:"max-results,omitempty"`
+}
+
+// ExpandOptions specifies which Hipchat collections to automatically expand.
+// This functionality is primarily used to reduce the total time to receive the data.
+// It also reduces the sheer number of API calls from 1+N, to 1.
+//
+// cf:  https://developer.atlassian.com/hipchat/guide/hipchat-rest-api/api-title-expansion
+type ExpandOptions struct {
+	Expand string `url:"expand,omitempty"`
 }
 
 // Color is set of hard-coded string values for the HipChat API for notifications.

--- a/hipchat/room.go
+++ b/hipchat/room.go
@@ -360,6 +360,7 @@ func (c *Card) AddAttribute(mainLabel, subLabel, url, iconURL string) {
 // method.
 type RoomsListOptions struct {
 	ListOptions
+	ExpandOptions
 
 	// Include private rooms in the result, API defaults to true
 	IncludePrivate bool `url:"include-private,omitempty"`
@@ -499,6 +500,7 @@ func (r *RoomService) Update(id string, roomReq *UpdateRoomRequest) (*http.Respo
 // HistoryOptions represents a HipChat room chat history request.
 type HistoryOptions struct {
 	ListOptions
+	ExpandOptions
 
 	// Either the latest date to fetch history for in ISO-8601 format, or 'recent' to fetch
 	// the latest 75 messages. Paging isn't supported for 'recent', however they are real-time

--- a/hipchat/room_test.go
+++ b/hipchat/room_test.go
@@ -54,6 +54,7 @@ func TestRoomList(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":      "1",
 			"max-results":      "10",
+			"expand":           "expansion",
 			"include-private":  "true",
 			"include-archived": "true",
 		})
@@ -66,7 +67,7 @@ func TestRoomList(t *testing.T) {
 		}`)
 	})
 	want := &Rooms{Items: []Room{{ID: 1, Name: "n"}}, StartIndex: 1, MaxResults: 1, Links: PageLinks{Links: Links{Self: "s"}}}
-	opt := &RoomsListOptions{ListOptions{1, 10}, true, true}
+	opt := &RoomsListOptions{ListOptions{1, 10}, ExpandOptions{"expansion"}, true, true}
 	rooms, _, err := client.Room.List(opt)
 	if err != nil {
 		t.Fatalf("Room.List returns an error %v", err)
@@ -257,6 +258,7 @@ func TestRoomHistory(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":     "1",
 			"max-results":     "100",
+			"expand":          "expansion",
 			"date":            "date",
 			"timezone":        "tz",
 			"reverse":         "true",
@@ -285,7 +287,7 @@ func TestRoomHistory(t *testing.T) {
 	})
 
 	opt := &HistoryOptions{
-		ListOptions{1, 100}, "date", "tz", true, "end-date", true,
+		ListOptions{1, 100}, ExpandOptions{"expansion"}, "date", "tz", true, "end-date", true,
 	}
 	hist, _, err := client.Room.History("1", opt)
 	if err != nil {

--- a/hipchat/user.go
+++ b/hipchat/user.go
@@ -121,6 +121,7 @@ func (u *UserService) Message(id string, msgReq *MessageRequest) (*http.Response
 // UserListOptions specified the parameters to the UserService.List method.
 type UserListOptions struct {
 	ListOptions
+	ExpandOptions
 	// Include active guest users in response.
 	IncludeGuests bool `url:"include-guests,omitempty"`
 	// Include deleted users in response.

--- a/hipchat/user_test.go
+++ b/hipchat/user_test.go
@@ -145,6 +145,7 @@ func TestUserList(t *testing.T) {
 		testFormValues(t, r, values{
 			"start-index":     "1",
 			"max-results":     "100",
+			"expand":          "expansion",
 			"include-guests":  "true",
 			"include-deleted": "true",
 		})
@@ -178,6 +179,7 @@ func TestUserList(t *testing.T) {
 
 	opt := &UserListOptions{
 		ListOptions{StartIndex: 1, MaxResults: 100},
+		ExpandOptions{"expansion"},
 		true, true,
 	}
 


### PR DESCRIPTION
Fixes #45

**MINOR BREAKING CHANGE**:

The structures `RoomsListOptions`, `UserListOptions`, and `HistoryOptions` each have
an additional member inserted named `ExpandOptions`.  If these were constructed using
positional arguments instead of the named argument idiom, a default `ExpandOptions{}`
will need to be inserted after the `ListOptions` to maintain the current behaviors.
