### PR TITLE
Fix slice bounds out of range

### DIFF
--- a/examples/hiptail/main.go
+++ b/examples/hiptail/main.go
@@ -42,7 +42,7 @@ func main() {
 		}
 		msg := m.Message
 		if len(m.Message) > (maxMsgLen - len(moreString)) {
-			msg = fmt.Sprintf("%s%s", strings.Replace(m.Message[:maxMsgLen], "\n", " - ", -1), moreString)
+			msg = fmt.Sprintf("%s%s", strings.Replace(m.Message[:len(m.Message)], "\n", " - ", -1), moreString)
 		}
 		fmt.Printf("%s [%s]: %s\n", from, m.Date, msg)
 	}


### PR DESCRIPTION
When I ran `examples/hiptail/main.go`, I got `slice bounds out of range` panic.

```
> go run `examples/hiptail/main.go` -token <TOKEN> -room <ROOM>
...
goroutine 1 [running]:
main.main()
        /Users/wenzhengjiang/Code/hipchat-go/examples/hiptail/main.go:45 +0x4df
exit status 2
```
This diff tries to fix the this error.